### PR TITLE
update compile.sh to use compute_scratch for forcing data

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -59,7 +59,7 @@ if [[ -d "${restart_folder}" ]]; then
 fi
 
 # check param_Forcing_Path
-forcing_path="/compute_shared/${param_Forcing_Path}"
+forcing_path="/compute_scratch/${param_Forcing_Path}"
 echo ${forcing_path}
 if [[ -d "${forcing_path}" ]]; then
     echo "forcing_path [${forcing_path}] provided by user. relinking..."


### PR DESCRIPTION
Making changes to forcing data location since Anvil will store files in scratch space without copying back to project space