### PR TITLE
Removed mem-per-cpu option in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,13 +20,6 @@
                 "min": 1,
                 "default_value": 4,
                 "step": 1
-            },
-            "memory_per_cpu": {
-                "max": 4,
-                "min": 1,
-                "default_value": 1,
-                "step": 1,
-                "unit": "GB"
             }    
     },
     "require_upload_data": true,


### PR DESCRIPTION
Removed the mem-per-cpu option since it seems to be clashing with Anvil's slurm config. See ticket: https://github.com/I-GUIDE/container_images/issues/11 